### PR TITLE
us-26

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -7,4 +7,16 @@ class Admin::MerchantsController < ApplicationController
   def show
     @merchant = Merchant.find(params[:id])
   end
+
+  
+  def edit 
+    @merchant = Merchant.find(params[:id])
+  end
+
+  def update
+    merchant = Merchant.find(params[:id])
+    merchant.update!(name: params[:name])
+    redirect_to admin_merchant_path(merchant)
+    flash[:notice] = 'Update Successful'
+  end
 end

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,0 +1,7 @@
+<h1> Update <%= @merchant.name %> </h1>
+<%= form_with url: admin_merchant_path(@merchant), method: :patch do |f| %>
+  <%= f.label :name, "Merchant Name: " %>
+  <%= f.text_field :name, value: @merchant.name %>
+
+  <%= f.submit "submit"%>
+<% end %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,1 +1,2 @@
-<h1>Merchant: <%=@merchant.name%></h1>
+<h1>Merchant: <%=@merchant.name%></h1> 
+<p><%= link_to "Update #{@merchant.name} Info", edit_admin_merchant_path(@merchant.id)  %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,9 @@
   </head>
 
   <body>
+    <% flash.each do |type, message|%>
+      <p> <%= message%> </p>
+    <%end%>
     <%= yield %>
   </body>
 </html>

--- a/spec/features/admin/mechants/show_spec.rb
+++ b/spec/features/admin/mechants/show_spec.rb
@@ -62,9 +62,35 @@ RSpec.describe 'Admin merchant show', type: :feature do
       click_link("#{@merch_1.name}")
       
       # Then I am taken to that merchant's admin show page (/admin/merchants/:merchant_id)
-      expect(current_path).to eq(admin_merchant_path(@merch_1.id))
+      expect(current_path).to eq(admin_merchant_path(@merch_1))
       # And I see the name of that merchant
       expect(page).to have_content("Merchant: Walmart")
+    end
+
+    # 26. Admin Merchant Update
+    it "can update merchant info" do 
+      # When I visit a merchant's admin show page (/admin/merchants/:merchant_id)
+      visit admin_merchant_path(@merch_1)
+      # Then I see a link to update the merchant's information.
+      expect(page).to have_link("Update #{@merch_1.name} Info")
+      # When I click the link
+      click_link("Update #{@merch_1.name} Info") 
+      # Then I am taken to a page to edit this merchant
+      expect(current_path).to eq(edit_admin_merchant_path(@merch_1))
+      # And I see a form filled in with the existing merchant attribute information
+      
+      expect(page).to have_field("Merchant Name:", with: "#{@merch_1.name}")
+     
+      fill_in "name", with: "Amazon"
+      # When I update the information in the form and I click ‘submit’
+      click_button("submit")
+      # Then I am redirected back to the merchant's admin show page where I see the updated information
+      expect(current_path).to eq(admin_merchant_path(@merch_1))
+      # And I see a flash message stating that the information has been successfully updated.
+      
+      expect(page).to have_content("Amazon")
+      expect(page).to have_content("Update Successful")
+      
     end
   end
 end


### PR DESCRIPTION
26. Admin Merchant Update

As an admin,
When I visit a merchant's admin show page (/admin/merchants/:merchant_id)
Then I see a link to update the merchant's information.
When I click the link
Then I am taken to a page to edit this merchant
And I see a form filled in with the existing merchant attribute information
When I update the information in the form and I click ‘submit’
Then I am redirected back to the merchant's admin show page where I see the updated information
And I see a flash message stating that the information has been successfully updated.