### PR TITLE
us-27

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -15,8 +15,17 @@ class Admin::MerchantsController < ApplicationController
 
   def update
     merchant = Merchant.find(params[:id])
-    merchant.update!(name: params[:name])
-    redirect_to admin_merchant_path(merchant)
-    flash[:notice] = 'Update Successful'
+   
+    if params[:update_status] == "disable"
+      merchant.update!(status: :disabled)
+      redirect_to admin_merchants_path
+    elsif params[:update_status] == "enable"
+      merchant.update!(status: :enabled)
+      redirect_to admin_merchants_path
+    else
+      merchant.update!(name: params[:name])
+      redirect_to admin_merchant_path(merchant)
+      flash[:notice] = 'Update Successful'
+    end
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,5 +1,6 @@
 class Merchant < ApplicationRecord
   validates :name, presence: true
+  enum status: { disabled: 0, enabled: 1 }
 
   has_many :items, dependent: :destroy
   has_many :invoices, through: :items

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -4,6 +4,12 @@
   <% @merchants.each do |merchant| %>
     <div id="merchant-<%= merchant.id %>">
       <p><%= link_to "#{merchant.name}", admin_merchant_path(merchant.id)  %></p>
+      <p> Status: <%= merchant.status.capitalize %></p>
+      <% if merchant.status == "enabled" %>
+        <p><%= button_to "disable", admin_merchant_path(merchant.id, update_status: "disable"), method: :patch  %></p>
+      <% else %>
+        <p><%= button_to "enable", admin_merchant_path(merchant.id, update_status: "enable"), method: :patch  %></p>
+      <% end %>  
     </div>
   <% end %>
 </section>

--- a/db/migrate/20240107024614_add_status_to_merchants.rb
+++ b/db/migrate/20240107024614_add_status_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddStatusToMerchants < ActiveRecord::Migration[7.0]
+  def change
+    add_column :merchants, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_06_190654) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_07_024614) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_06_190654) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/features/admin/admin_dashboard_spec.rb
+++ b/spec/features/admin/admin_dashboard_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe "admin dashboard" do
   before(:each) do 
-    @merch_1 = Merchant.create!(name: "Walmart")
-    @merch_2 = Merchant.create!(name: "Target")
+    @merch_1 = Merchant.create!(name: "Walmart", status: :enabled)
+    @merch_2 = Merchant.create!(name: "Target", status: :enabled)
 
     @item_1 = @merch_1.items.create!(name: "Apple", description: "red apple", unit_price:1)
     @item_2 = @merch_1.items.create!(name: "Orange", description: "orange orange", unit_price:1)

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
  RSpec.describe 'Admin Merchants', type: :feature do
   
   before(:each) do
-    @merch_1 = Merchant.create!(name: "Walmart")
-    @merch_2 = Merchant.create!(name: "Target")
+    @merch_1 = Merchant.create!(name: "Walmart", status: :enabled)
+    @merch_2 = Merchant.create!(name: "Target", status: :disabled)
 
     @item_1 = @merch_1.items.create!(name: "Apple", description: "red apple", unit_price:1)
     @item_2 = @merch_1.items.create!(name: "Orange", description: "orange orange", unit_price:1)
@@ -62,6 +62,31 @@ require 'rails_helper'
     within '.merchants-index' do
       expect(page).to have_content("Walmart")
       expect(page).to have_content("Target")
+    end
+  end
+
+  # 27. Admin Merchant Enable/Disable
+  it "can disable the merchant" do
+    # When I visit the admin merchants index (/admin/merchants)
+    visit admin_merchants_path
+    # Then next to each merchant name I see a button to disable or enable that merchant.
+    within "#merchant-#{@merch_1.id}" do
+      expect(page).to have_button("disable")
+      expect(page).to have_content("Status: Enabled")
+    end
+    within "#merchant-#{@merch_2.id}" do
+      expect(page).to have_button("enable")
+    end
+    # When I click this button
+    within "#merchant-#{@merch_1.id}" do
+      click_button("disable")
+    end
+    # Then I am redirected back to the admin merchants index
+    expect(current_path).to eq(admin_merchants_path)
+    # And I see that the merchant's status has changed
+    within "#merchant-#{@merch_1.id}" do
+      expect(page).to have_button("enable")
+      expect(page).to have_content("Status: Disabled")
     end
   end
 end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Admin merchant show', type: :feature do
   describe '' do
     before(:each) do
-      @merch_1 = Merchant.create!(name: "Walmart")
-      @merch_2 = Merchant.create!(name: "Target")
+      @merch_1 = Merchant.create!(name: "Walmart", status: :enabled)
+      @merch_2 = Merchant.create!(name: "Target", status: :enabled)
   
       @item_1 = @merch_1.items.create!(name: "Apple", description: "red apple", unit_price:1)
       @item_2 = @merch_1.items.create!(name: "Orange", description: "orange orange", unit_price:1)

--- a/spec/features/merchants/items/edit_spec.rb
+++ b/spec/features/merchants/items/edit_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe "Merchants/Items Edit Page", type: :feature do
   it "has a link to update/edit item information on merchant item show page " do
-    merchant_1 = Merchant.create!(name: "Walmart")
-    merchant_2 = Merchant.create!(name: "Amazon")
+    merchant_1 = Merchant.create!(name: "Walmart", status: :enabled)
+    merchant_2 = Merchant.create!(name: "Amazon", status: :enabled)
     walmart_items = create_list(:item, 37, merchant_id: merchant_1.id)
     amazon_items = create_list(:item, 43, merchant_id: merchant_2.id)
 

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe "Merchants/Items Index Page", type: :feature do
   it "shows a list of all of my items and not for other merchants" do
-    merchant_1 = Merchant.create!(name: "Walmart")
-    merchant_2 = Merchant.create!(name: "Amazon")
+    merchant_1 = Merchant.create!(name: "Walmart", status: :enabled)
+    merchant_2 = Merchant.create!(name: "Amazon", status: :enabled)
     walmart_items = create_list(:item, 37, merchant_id: merchant_1.id)
     amazon_items = create_list(:item, 43, merchant_id: merchant_2.id)
 

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Merchants Items Show Page", type: :feature do
   it "shows the item's attributes including name, description and current price" do
-    merchant_1 = Merchant.create!(name: "Walmart")
+    merchant_1 = Merchant.create!(name: "Walmart", status: :enabled)
     walmart_items = create_list(:item, 3, merchant_id: merchant_1.id)
 
     visit "/merchants/#{merchant_1.id}/items"

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "show page" do
   before (:each) do
-    @merchant_1 = Merchant.create!(name: "Walmart")
+    @merchant_1 = Merchant.create!(name: "Walmart", status: :enabled)
     @items = create_list(:item, 31, merchant: @merchant_1)
     @customers = create_list(:customer, 13)
     @customers_with_transactions = create_list(:customer_with_transactions, 13)


### PR DESCRIPTION
27. Admin Merchant Enable/Disable

As an admin,
When I visit the admin merchants index (/admin/merchants)
Then next to each merchant name I see a button to disable or enable that merchant.
When I click this button
Then I am redirected back to the admin merchants index
And I see that the merchant's status has changed