### PR TITLE
US story 28 & 29 

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -28,4 +28,19 @@ class Admin::MerchantsController < ApplicationController
       flash[:notice] = 'Update Successful'
     end
   end
+
+  def create 
+    merchant = Merchant.new(merchant_params)
+    if merchant.save 
+      redirect_to admin_merchants_path
+    else 
+      flash[:error] = "Error: All fields must be filled in to submit"
+      redirect_to new_admin_merchant_path
+    end
+  end
+
+  private
+  def merchant_params
+    params.permit(:name, :id, :status)
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -7,6 +7,7 @@ class Merchant < ApplicationRecord
   has_many :invoice_items, through: :items
   has_many :customers, through: :invoices
   has_many :transactions, through: :invoices
+  
 
   def transactions
     Transaction.joins(invoice: { invoice_items: :item }).where(items: { merchant_id: id })

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -14,3 +14,29 @@
   <% end %>
 </section>
 
+<section id = "enabled_merch">
+    <p>Enabled Merchants:</p>
+  <% @merchants.each do |merchant| %>
+    <% if merchant.status == "enabled" %>
+    <ul>
+      <li><%= merchant.name%></li></br>
+    </ul>
+    <% end %>
+  <% end %>
+</section>
+
+<section id = "disabled_merch">
+    <p>Disabled Merchants:</p>
+  <% @merchants.each do |merchant| %>
+    <% if merchant.status == "disabled" %>
+    <ul>
+      <li><%= merchant.name%></li></br>
+    </ul>
+    <% end %>
+  <% end %>
+</section>
+
+<%= link_to 'Create Merchant',  new_admin_merchant_path %>
+
+
+

--- a/app/views/admin/merchants/new.html.erb
+++ b/app/views/admin/merchants/new.html.erb
@@ -1,0 +1,5 @@
+<%= form_with url:  admin_merchants_path, method: :post , data: {turbo: false} do |f| %>
+  <%= f.label :name%>
+  <%= f.text_field :name%>
+  <%= f.submit "Submit" %>
+<% end %>

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -6,6 +6,8 @@ require 'rails_helper'
   before(:each) do
     @merch_1 = Merchant.create!(name: "Walmart", status: :enabled)
     @merch_2 = Merchant.create!(name: "Target", status: :disabled)
+    @merch_3 = Merchant.create!(name: "PetSmart", status: :disabled)
+    @merch_4 = Merchant.create!(name: "GameStop", status: :enabled)
 
     @item_1 = @merch_1.items.create!(name: "Apple", description: "red apple", unit_price:1)
     @item_2 = @merch_1.items.create!(name: "Orange", description: "orange orange", unit_price:1)
@@ -53,6 +55,8 @@ require 'rails_helper'
     @ii_17 = InvoiceItem.create!(invoice: @inv_6, item: @item_2, quantity: 10, unit_price: 1, status: :shipped )
     @ii_18= InvoiceItem.create!(invoice: @inv_6, item: @item_3, quantity: 10, unit_price: 1, status: :shipped )
     @ii_19 = InvoiceItem.create!(invoice: @inv_6, item: @item_4, quantity: 10, unit_price: 1, status: :pending )
+
+    visit admin_merchants_path
   end
 
   it 'displays the name of each merchant' do
@@ -87,6 +91,28 @@ require 'rails_helper'
     within "#merchant-#{@merch_1.id}" do
       expect(page).to have_button("enable")
       expect(page).to have_content("Status: Disabled")
+    end
+  end
+
+  # User 28 
+  it "I see a section for Enabled Merchants" do 
+    within "#enabled_merch" do 
+      expect(page).to have_content(@merch_1.name)
+      expect(page).to have_content(@merch_4.name)
+      save_and_open_page
+      expect(page).to_not have_content(@merch_2.name)
+      expect(page).to_not have_content(@merch_3.name)
+    end
+  end
+
+  it "I see a section for disabled Merchants" do 
+    within "#disabled_merch" do 
+      expect(page).to have_content(@merch_2.name)
+      expect(page).to have_content(@merch_3.name)
+
+      expect(page).to_not have_content(@merch_1.name)
+      expect(page).to_not have_content(@merch_4.name)
+      
     end
   end
 end

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -1,0 +1,40 @@
+
+require 'rails_helper'
+ 
+RSpec.describe 'Admin Merchants Create', type: :feature do
+  
+  before(:each) do
+
+    visit admin_merchants_path
+
+    click_on "Create Merchant"
+  end
+
+  it "create a new merch" do 
+    expect(current_path).to eq(new_admin_merchant_path)
+
+    fill_in :name, with: "Popeyes"
+    
+    click_on "Submit"
+    
+    save_and_open_page
+    expect(current_path).to eq(admin_merchants_path)
+
+    within "#disabled_merch" do 
+      expect(page).to have_content("Popeyes")
+    end
+  end
+
+  it "sad path for create" do
+
+    expect(current_path).to eq(new_admin_merchant_path)
+
+    fill_in :name, with: ""
+    
+    click_on "Submit"
+    save_and_open_page
+    expect(current_path).to eq(new_admin_merchant_path)
+
+    expect(page).to have_content("Error: All fields must be filled in to submit")
+  end 
+end


### PR DESCRIPTION

In this PR I made an enable and disabled merchant section in the view with happy and sad path testing! Also made a create action for the admin merchant with happy and sad path testing!


28. Admin Merchants Grouped by Status

As an admin,
When I visit the admin merchants index (/admin/merchants)
Then I see two sections, one for "Enabled Merchants" and one for "Disabled Merchants"
And I see that each Merchant is listed in the appropriate section


29. Admin Merchant Create

As an admin,
When I visit the admin merchants index (/admin/merchants)
I see a link to create a new merchant.
When I click on the link,
I am taken to a form that allows me to add merchant information.
When I fill out the form I click ‘Submit’
Then I am taken back to the admin merchants index page
And I see the merchant I just created displayed
And I see my merchant was created with a default status of disabled.
