### PR TITLE
36 admin invoice show

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -6,4 +6,16 @@ class Admin::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
   end
+
+  def update
+    invoice = Invoice.find(params[:id])
+    if params[:status] == "cancelled"
+      invoice.update!(status: :cancelled)
+    elsif params[:status] == "completed"
+      invoice.update!(status: :completed)
+    elsif params[:status] == "in progress"
+      invoice.update!(status: :in_progress)
+    end 
+    redirect_to admin_invoice_path(invoice)
+  end
  end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -12,8 +12,4 @@ class Customer < ApplicationRecord
       .order("success_count DESC")
       .limit(5)
   end
-
-  def full_name
-    "#{first_name} #{last_name}"
-  end
 end

--- a/app/views/admin/invoices/index.html.erb
+++ b/app/views/admin/invoices/index.html.erb
@@ -4,3 +4,4 @@
     <p><%= link_to "#{invoice.id}", admin_invoice_path(invoice) %></p>
 <% end %>
 
+

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,7 +1,7 @@
 <h1><%=@invoice.id%></h1>
 <p><%=@invoice.status%></p>
 <p><%=@invoice.created_at.strftime("%A, %B %d, %Y")%></p>
-<p><%=@invoice.customer.full_name%></p>
+<p><%=@invoice.customer.first_name%> <%=@invoice.customer.last_name  %></p>
 
 
 <section class = "status-update">

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -2,3 +2,13 @@
 <p><%=@invoice.status%></p>
 <p><%=@invoice.created_at.strftime("%A, %B %d, %Y")%></p>
 <p><%=@invoice.customer.full_name%></p>
+
+
+<section class = "status-update">
+  <p>Current Status: <%=@invoice.status %></p>
+  <%= form_with url: admin_invoice_path(@invoice) , method: :patch , local: true do |f| %>
+    <%=f.label :status%>
+    <%=f.select :status, ["in progress", "completed", "cancelled"]%>
+    <%=f.submit "Update"%>
+  <% end %>
+</section>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -66,5 +66,18 @@ RSpec.describe 'Admin Show Spec', type: :feature do
       expect(page).to have_content(@inv_1.created_at.strftime("%A, %B %d, %Y"))
       expect(page).to have_content(@inv_1.customer.full_name)
     end
+
+    it "Update invoice status" do 
+      visit admin_invoice_path(@inv_3)
+
+      within ".status-update" do 
+        expect(page).to have_content("Current Status: completed")
+
+        select("cancelled", from: "status")
+        click_button "Update"
+      
+        expect(page).to have_content("Current Status: cancelled")
+      end 
+    end
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -64,7 +64,8 @@ RSpec.describe 'Admin Show Spec', type: :feature do
       expect(page).to have_content(@inv_1.id)
       expect(page).to have_content(@inv_1.status)
       expect(page).to have_content(@inv_1.created_at.strftime("%A, %B %d, %Y"))
-      expect(page).to have_content(@inv_1.customer.full_name)
+      expect(page).to have_content("#{@inv_1.customer.first_name} #{@inv_1.customer.last_name}")
+      save_and_open_page
     end
 
     it "Update invoice status" do 


### PR DESCRIPTION
36. Admin Invoice Show Page: Update Invoice Status

As an admin     
When I visit an admin invoice show page (/admin/invoices/:invoice_id)
I see the invoice status is a select field
And I see that the invoice's current status is selected
When I click this select field,
Then I can select a new status for the Invoice,
And next to the select field I see a button to "Update Invoice Status"
When I click this button
I am taken back to the admin invoice show page
And I see that my Invoice's status has now been updated