### PR TITLE
us-34

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -26,4 +26,16 @@ class Item < ApplicationRecord
     LIMIT 1;"])
     date.first.date.to_fs(:long)
   end
+
+  def quantity_ordered(item_id, invoice_id)
+    invoice_items.where(item_id: item_id, invoice_id: invoice_id)
+      .pluck(:quantity)
+      .first
+  end
+
+  def invoice_status(item_id, invoice_id)
+    invoice_items.where(item_id: item_id, invoice_id: invoice_id)
+      .pluck(:status)
+      .first
+  end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -12,3 +12,12 @@
     <%=f.submit "Update"%>
   <% end %>
 </section>
+
+<% @invoice.items.each do |item| %>
+  <section id="item-details-<%= item.id %>">
+    <p><%= item.name %></p>
+    <p><%= item.quantity_ordered(item.id, @invoice.id) %></p>
+    <p><%= item.unit_price %></p>
+    <p><%= item.invoice_status(item.id, @invoice.id) %></p>
+  </section>
+<% end %>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -80,5 +80,36 @@ RSpec.describe 'Admin Show Spec', type: :feature do
         expect(page).to have_content("Current Status: cancelled")
       end 
     end
+
+    # 34. Admin Invoice Show Page: Invoice Item Information
+    it "displays item info" do 
+      # When I visit an admin invoice show page (/admin/invoices/:invoice_id)
+      visit admin_invoice_path(@inv_1)
+      # Then I see all of the items on the invoice including:
+      # - Item name
+      # - The quantity of the item ordered
+      # - The price the Item sold for
+      # - The Invoice Item status
+      within "#item-details-#{@item_1.id}" do
+        expect(page).to have_content(@item_1.name)
+        expect(page).to have_content(@ii_1.quantity)
+        expect(page).to have_content(@item_1.unit_price)
+        expect(page).to have_content(@ii_1.status)
+      end
+
+      within "#item-details-#{@item_2.id}" do
+        expect(page).to have_content(@item_2.name)
+        expect(page).to have_content(@ii_2.quantity)
+        expect(page).to have_content(@item_2.unit_price)
+        expect(page).to have_content(@ii_2.status)
+      end
+
+      within "#item-details-#{@item_3.id}" do
+        expect(page).to have_content(@item_3.name)
+        expect(page).to have_content(@ii_1.quantity)
+        expect(page).to have_content(@item_3.unit_price)
+        expect(page).to have_content(@ii_3.status)
+      end
+    end
   end
 end


### PR DESCRIPTION
34. Admin Invoice Show Page: Invoice Item Information

As an admin
When I visit an admin invoice show page (/admin/invoices/:invoice_id)
Then I see all of the items on the invoice including:
- Item name
- The quantity of the item ordered
- The price the Item sold for
- The Invoice Item status