### PR TITLE
35 admin invoice show page

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -18,4 +18,10 @@ class Invoice < ApplicationRecord
     # require 'pry'; binding.pry
   end
 
+
+  def total_revenue
+    self.invoice_items.joins(:item)
+      .sum("invoice_items.quantity * invoice_items.unit_price")
+  end
+
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -21,3 +21,6 @@
     <p><%= item.invoice_status(item.id, @invoice.id) %></p>
   </section>
 <% end %>
+
+
+<h2>Total Revenue: <%= @invoice.total_revenue%></h2>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -111,5 +111,11 @@ RSpec.describe 'Admin Show Spec', type: :feature do
         expect(page).to have_content(@ii_3.status)
       end
     end
+
+    it 'Shows an invoices total revenue' do
+      visit admin_invoice_path(@inv_1)
+
+      expect(page).to have_content(@inv_1.total_revenue)
+    end
   end
 end


### PR DESCRIPTION
35. Admin Invoice Show Page: Total Revenue

As an admin
When I visit an admin invoice show page (/admin/invoices/:invoice_id)
Then I see the total revenue that will be generated from this invoice.
